### PR TITLE
Fix Encdroid now syncs back modified keepassdroid .kdb/x databases

### DIFF
--- a/src/org/mrpdaemon/android/encdroid/EDVolumeBrowserActivity.java
+++ b/src/org/mrpdaemon/android/encdroid/EDVolumeBrowserActivity.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.sql.Date;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -162,6 +163,9 @@ public class EDVolumeBrowserActivity extends ListActivity {
 
 	// File observer
 	private EDFileObserver mFileObserver;
+
+	// Original file's modified timestamp
+	private Date mOrigModifiedDate;
 
 	// EncFSFile that is currently opened
 	private EncFSFile mOpenFile;
@@ -869,7 +873,8 @@ public class EDVolumeBrowserActivity extends ListActivity {
 			File dstFile = new File(mFileObserver.getPath());
 
 			// If the file was modified we need to sync it back
-			if (mFileObserver.wasModified()) {
+			Date newDate=new Date(dstFile.lastModified());
+			if (mFileObserver.wasModified() || (newDate.compareTo(mOrigModifiedDate)>0) ) {
 				// Sync file contents
 				try {
 					launchAsyncTask(ASYNC_TASK_SYNC, dstFile, mOpenFile);
@@ -1594,6 +1599,7 @@ public class EDVolumeBrowserActivity extends ListActivity {
 							dstFile.getAbsolutePath());
 					mFileObserver.startWatching();
 
+					mOrigModifiedDate=new Date(dstFile.lastModified());
 					// Figure out the MIME type
 					String fileName = dstFile.getName();
 					String extension = MimeTypeMap


### PR DESCRIPTION
this fix is for :https://github.com/mrpdaemon/encdroid/issues/35
Unable to update KeepassDroid database files in local volume

With this fix, i am able to sync back the keepass databases to encdroid containers.
