### PR TITLE
Optional PINs per volume, to protect volume passwords a little more

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="no_volumes">No EncFS volumes configured. Choose \&quot;Import Volume\&quot; or \&quot;Create Volume\&quot;  from the menu to add volumes.</string>
     <string name="menu_select">Select</string>
     <string name="pwd_dialog_title_str">Enter password:</string>
+    <string name="pin_dialog_title_str">Enter PIN:</string>
+    <string name="set_pin_dialog_title_str">Set PIN (leave empty for no PIN):</string>
     <string name="btn_ok_str">OK</string>
     <string name="pbkdf_dialog_title_str">Deriving password key</string>
     <string name="pbkdf_dialog_msg_str">Can take VERY long for some volumes. Consider enabling password key caching in Settings.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="pin_dialog_title_str">Enter PIN:</string>
     <string name="set_pin_dialog_title_str">Set PIN (leave empty for no PIN):</string>
     <string name="error_wrong_pin">Wrong PIN entered!</string>
+    <string name="error_wrong_pin_three_times">Wrong PIN entered three times! Volume password has been deleted.</string>
     <string name="btn_ok_str">OK</string>
     <string name="pbkdf_dialog_title_str">Deriving password key</string>
     <string name="pbkdf_dialog_msg_str">Can take VERY long for some volumes. Consider enabling password key caching in Settings.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="pwd_dialog_title_str">Enter password:</string>
     <string name="pin_dialog_title_str">Enter PIN:</string>
     <string name="set_pin_dialog_title_str">Set PIN (leave empty for no PIN):</string>
+    <string name="error_wrong_pin">Wrong PIN entered!</string>
     <string name="btn_ok_str">OK</string>
     <string name="pbkdf_dialog_title_str">Deriving password key</string>
     <string name="pbkdf_dialog_msg_str">Can take VERY long for some volumes. Consider enabling password key caching in Settings.</string>

--- a/src/org/mrpdaemon/android/encdroid/DBHelper.java
+++ b/src/org/mrpdaemon/android/encdroid/DBHelper.java
@@ -201,6 +201,15 @@ public class DBHelper extends SQLiteOpenHelper {
 
 		db.execSQL("UPDATE " + DB_TABLE + " SET " + DB_COL_KEY + " = NULL");
 	}
+	
+	public void clearAllPINs() {
+		SQLiteDatabase db = getWritableDatabase();
+
+		Log.d(TAG, "clearAllPINs()");
+
+		db.execSQL("UPDATE " + DB_TABLE + " SET " + DB_COL_PIN + " = NULL");
+		db.execSQL("UPDATE " + DB_TABLE + " SET " + DB_COL_PINATTEMPTS + " = 0");
+	}
 
 	public byte[] getCachedKey(Volume volume) {
 		SQLiteDatabase db = getReadableDatabase();

--- a/src/org/mrpdaemon/android/encdroid/DBHelper.java
+++ b/src/org/mrpdaemon/android/encdroid/DBHelper.java
@@ -39,7 +39,7 @@ public class DBHelper extends SQLiteOpenHelper {
 	public static final String DB_NAME = "volume.db";
 
 	// Database version
-	public static final int DB_VERSION = 4;
+	public static final int DB_VERSION = 5;
 
 	// Volume table name
 	public static final String DB_TABLE = "volumes";
@@ -77,11 +77,17 @@ public class DBHelper extends SQLiteOpenHelper {
 
 	@Override
 	public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-		// Adding column DB_COL_CONFIGPATH on upgrade
-		if (oldVersion == 3) {
+		// Adding missing columns on upgrade
+		if (oldVersion == 3 || oldVersion == 4) {
 			Log.d(TAG, "onUpgrade() Upgrading DB");
+			if(oldVersion == 3) {
+				db.execSQL("ALTER TABLE " + DB_TABLE + " ADD COLUMN "
+						+ DB_COL_CONFIGPATH + " TEXT");
+			}
 			db.execSQL("ALTER TABLE " + DB_TABLE + " ADD COLUMN "
-					+ DB_COL_CONFIGPATH + " TEXT");
+					+ DB_COL_PIN + " TEXT");
+			db.execSQL("ALTER TABLE " + DB_TABLE + " ADD COLUMN "
+					+ DB_COL_PINATTEMPTS + " INT");
 		} else {
 			db.execSQL("DROP TABLE IF EXISTS " + DB_TABLE);
 			Log.d(TAG, "onUpgrade() recreating DB");

--- a/src/org/mrpdaemon/android/encdroid/DBHelper.java
+++ b/src/org/mrpdaemon/android/encdroid/DBHelper.java
@@ -51,6 +51,8 @@ public class DBHelper extends SQLiteOpenHelper {
 	public static final String DB_COL_CONFIGPATH = "configPath";
 	public static final String DB_COL_TYPE = "type";
 	public static final String DB_COL_KEY = "key";
+	public static final String DB_COL_PIN = "pin";
+	public static final String DB_COL_PINCOUNTER = "pinctr"; // counts unsuccessful PIN attempts
 
 	private static final String[] NO_ARGS = {};
 
@@ -67,7 +69,7 @@ public class DBHelper extends SQLiteOpenHelper {
 	public void onCreate(SQLiteDatabase db) {
 		String sqlCmd = "CREATE TABLE " + DB_TABLE + " (" + DB_COL_ID
 				+ " int primary key, " + DB_COL_NAME + " text, " + DB_COL_PATH
-				+ " text, " + DB_COL_KEY + " text, " + DB_COL_TYPE + " int, "
+				+ " text, " + DB_COL_KEY + " text, " + DB_COL_PIN + " text, "+ DB_COL_PINCOUNTER + " int, "+ DB_COL_TYPE + " int, "
 				+ DB_COL_CONFIGPATH + " text)";
 		Log.d(TAG, "onCreate() executing SQL: " + sqlCmd);
 		db.execSQL(sqlCmd);
@@ -140,6 +142,17 @@ public class DBHelper extends SQLiteOpenHelper {
 		db.update(DB_TABLE, values, DB_COL_NAME + "=? AND " + DB_COL_PATH
 				+ "=?", new String[] { volume.getName(), volume.getPath() });
 	}
+	
+	public void setPIN(Volume volume, String pin) {
+		SQLiteDatabase db = getWritableDatabase();
+
+		Log.d(TAG, "setPIN() for volume" + volume.getName());
+
+		ContentValues values = new ContentValues();
+		values.put(DB_COL_PIN, pin);
+		db.update(DB_TABLE, values, DB_COL_NAME + "=? AND " + DB_COL_PATH
+				+ "=?", new String[] { volume.getName(), volume.getPath() });
+	}
 
 	public void clearKey(Volume volume) {
 		SQLiteDatabase db = getWritableDatabase();
@@ -148,6 +161,17 @@ public class DBHelper extends SQLiteOpenHelper {
 
 		ContentValues values = new ContentValues();
 		values.putNull(DB_COL_KEY);
+		db.update(DB_TABLE, values, DB_COL_NAME + "=? AND " + DB_COL_PATH
+				+ "=?", new String[] { volume.getName(), volume.getPath() });
+	}
+	
+	public void clearPIN(Volume volume) {
+		SQLiteDatabase db = getWritableDatabase();
+
+		Log.d(TAG, "clearPIN() for volume" + volume.getName());
+
+		ContentValues values = new ContentValues();
+		values.putNull(DB_COL_PIN);
 		db.update(DB_TABLE, values, DB_COL_NAME + "=? AND " + DB_COL_PATH
 				+ "=?", new String[] { volume.getName(), volume.getPath() });
 	}
@@ -175,6 +199,21 @@ public class DBHelper extends SQLiteOpenHelper {
 			}
 		}
 
+		return null;
+	}
+	
+	public String getPIN(Volume volume) {
+		SQLiteDatabase db = getReadableDatabase();
+
+		Cursor cursor = db.query(DB_TABLE, NO_ARGS, DB_COL_NAME + "=? AND "
+				+ DB_COL_PATH + "=?",
+				new String[] { volume.getName(), volume.getPath() }, null,
+				null, null);
+
+		if (cursor.moveToFirst()) {
+			String pin = cursor.getString(cursor.getColumnIndex(DB_COL_PIN));
+			return pin;
+		}
 		return null;
 	}
 

--- a/src/org/mrpdaemon/android/encdroid/DBHelper.java
+++ b/src/org/mrpdaemon/android/encdroid/DBHelper.java
@@ -52,7 +52,7 @@ public class DBHelper extends SQLiteOpenHelper {
 	public static final String DB_COL_TYPE = "type";
 	public static final String DB_COL_KEY = "key";
 	public static final String DB_COL_PIN = "pin";
-	public static final String DB_COL_PINCOUNTER = "pinctr"; // counts unsuccessful PIN attempts
+	public static final String DB_COL_PINATTEMPTS = "pinAttempts"; // counts unsuccessful PIN attempts
 
 	private static final String[] NO_ARGS = {};
 
@@ -69,7 +69,7 @@ public class DBHelper extends SQLiteOpenHelper {
 	public void onCreate(SQLiteDatabase db) {
 		String sqlCmd = "CREATE TABLE " + DB_TABLE + " (" + DB_COL_ID
 				+ " int primary key, " + DB_COL_NAME + " text, " + DB_COL_PATH
-				+ " text, " + DB_COL_KEY + " text, " + DB_COL_PIN + " text, "+ DB_COL_PINCOUNTER + " int, "+ DB_COL_TYPE + " int, "
+				+ " text, " + DB_COL_KEY + " text, " + DB_COL_PIN + " text, "+ DB_COL_PINATTEMPTS + " int, "+ DB_COL_TYPE + " int, "
 				+ DB_COL_CONFIGPATH + " text)";
 		Log.d(TAG, "onCreate() executing SQL: " + sqlCmd);
 		db.execSQL(sqlCmd);
@@ -153,7 +153,18 @@ public class DBHelper extends SQLiteOpenHelper {
 		db.update(DB_TABLE, values, DB_COL_NAME + "=? AND " + DB_COL_PATH
 				+ "=?", new String[] { volume.getName(), volume.getPath() });
 	}
+	
+	public void setPINAttempts(Volume volume, int newVal) {
+		SQLiteDatabase db = getWritableDatabase();
 
+		Log.d(TAG, "setPINAttempts() " + volume.getName() + " to " + newVal);
+
+		ContentValues values = new ContentValues();
+		values.put(DB_COL_PINATTEMPTS, newVal);
+		db.update(DB_TABLE, values, DB_COL_NAME + "=? AND " + DB_COL_PATH
+				+ "=?", new String[] { volume.getName(), volume.getPath() });
+	}
+	
 	public void clearKey(Volume volume) {
 		SQLiteDatabase db = getWritableDatabase();
 
@@ -172,6 +183,7 @@ public class DBHelper extends SQLiteOpenHelper {
 
 		ContentValues values = new ContentValues();
 		values.putNull(DB_COL_PIN);
+		values.putNull(DB_COL_PINATTEMPTS);
 		db.update(DB_TABLE, values, DB_COL_NAME + "=? AND " + DB_COL_PATH
 				+ "=?", new String[] { volume.getName(), volume.getPath() });
 	}
@@ -198,7 +210,6 @@ public class DBHelper extends SQLiteOpenHelper {
 				return Base64.decode(keyStr, Base64.DEFAULT);
 			}
 		}
-
 		return null;
 	}
 	
@@ -215,6 +226,21 @@ public class DBHelper extends SQLiteOpenHelper {
 			return pin;
 		}
 		return null;
+	}
+	
+	public int getPINAttempts(Volume volume) {
+		SQLiteDatabase db = getReadableDatabase();
+
+		Cursor cursor = db.query(DB_TABLE, NO_ARGS, DB_COL_NAME + "=? AND "
+				+ DB_COL_PATH + "=?",
+				new String[] { volume.getName(), volume.getPath() }, null,
+				null, null);
+
+		if (cursor.moveToFirst()) {
+			int pinAttempts = cursor.getInt((cursor.getColumnIndex(DB_COL_PINATTEMPTS)));
+			return pinAttempts;
+		}
+		return 0;
 	}
 
 	public List<Volume> getVolumes() {

--- a/src/org/mrpdaemon/android/encdroid/EDPreferenceActivity.java
+++ b/src/org/mrpdaemon/android/encdroid/EDPreferenceActivity.java
@@ -137,6 +137,8 @@ public class EDPreferenceActivity extends Activity {
 					Log.d(TAG, "Key caching disabled, clearing cached keys.");
 					// Need to clear all cached keys
 					mApp.getDbHelper().clearAllKeys();
+					// Might need to clear all saved PINs as well
+					mApp.getDbHelper().clearAllPINs();
 				} else {
 					Log.d(TAG, "Key caching enabled.");
 				}

--- a/src/org/mrpdaemon/android/encdroid/VolumeListActivity.java
+++ b/src/org/mrpdaemon/android/encdroid/VolumeListActivity.java
@@ -873,7 +873,8 @@ public class VolumeListActivity extends ListActivity implements
 				// a wrong PIN was given
 				// TODO: increment / check fail counter
 				//userPin = null;
-				showDialog(DIALOG_VOL_PIN);
+				mErrDialogText = getString(R.string.error_wrong_pin);
+				showDialog(DIALOG_ERROR);
 				return;
 			}
 		}

--- a/src/org/mrpdaemon/android/encdroid/VolumeListActivity.java
+++ b/src/org/mrpdaemon/android/encdroid/VolumeListActivity.java
@@ -86,6 +86,8 @@ public class VolumeListActivity extends ListActivity implements
 	private final static int DIALOG_VOL_DELETE = 5;
 	private final static int DIALOG_FS_TYPE = 6;
 	private final static int DIALOG_ERROR = 7;
+	private final static int DIALOG_VOL_PIN = 8;
+	private final static int DIALOG_VOL_SETPIN = 9;
 
 	// Volume operation types
 	private final static int VOLUME_OP_IMPORT = 0;
@@ -336,6 +338,20 @@ public class VolumeListActivity extends ListActivity implements
 							| InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
 				}
 			}
+		case DIALOG_VOL_PIN:
+			if (id == DIALOG_VOL_PIN) {
+				if (input != null) {
+					input.setInputType(InputType.TYPE_NUMBER_VARIATION_PASSWORD
+							| InputType.TYPE_CLASS_NUMBER);
+				}
+			}
+		case DIALOG_VOL_SETPIN:
+			if (id == DIALOG_VOL_SETPIN) {
+				if (input != null) {
+					input.setInputType(InputType.TYPE_NUMBER_VARIATION_PASSWORD
+							| InputType.TYPE_CLASS_NUMBER);
+				}
+			}
 		case DIALOG_VOL_CREATEPASS:
 		case DIALOG_VOL_NAME:
 		case DIALOG_VOL_CREATE:
@@ -418,6 +434,8 @@ public class VolumeListActivity extends ListActivity implements
 
 		switch (id) {
 		case DIALOG_VOL_PASS: // Password dialog
+		case DIALOG_VOL_PIN:  // Enter PIN dialog
+		case DIALOG_VOL_SETPIN: // Set PIN dialog
 			if (mSelectedVolume == null) {
 				// Can happen when restoring a killed activity
 				return null;
@@ -429,8 +447,17 @@ public class VolumeListActivity extends ListActivity implements
 
 			// Hide password input
 			input.setTransformationMethod(new PasswordTransformationMethod());
-
-			alertBuilder.setTitle(getString(R.string.pwd_dialog_title_str));
+			
+			String titleString;
+			if(id == DIALOG_VOL_PIN) {
+				titleString = getString(R.string.pin_dialog_title_str);
+			} else if (id == DIALOG_VOL_SETPIN) {
+				titleString = getString(R.string.set_pin_dialog_title_str);
+			} else {
+				titleString = getString(R.string.pwd_dialog_title_str);
+			}
+			
+			alertBuilder.setTitle(titleString);
 			alertBuilder.setView(input);
 			alertBuilder.setPositiveButton(getString(R.string.btn_ok_str),
 					new DialogInterface.OnClickListener() {
@@ -454,6 +481,19 @@ public class VolumeListActivity extends ListActivity implements
 												.getCustomConfigPath());
 								addTaskFragment(unlockTask);
 								unlockTask.startTask();
+								break;
+							case DIALOG_VOL_PIN:
+								// Unlock with cached pass and PIN
+								unlockSelectedVolume(value.toString());
+								break;
+							case DIALOG_VOL_SETPIN:
+								
+								if(value.length() > 0) {
+									mApp.getDbHelper().setPIN(mSelectedVolume,value.toString());
+								}
+								
+								// TODO: does this open the correct volume?
+								launchVolumeBrowser(mSelectedVolIdx);
 								break;
 							case DIALOG_VOL_CREATEPASS:
 								// Launch async task to create volume
@@ -805,14 +845,40 @@ public class VolumeListActivity extends ListActivity implements
 	 * Unlock the currently selected volume
 	 */
 	private void unlockSelectedVolume() {
+		unlockSelectedVolume(null);
+	}
+	
+	/**
+	 * Unlock the currently selected volume using a PIN
+	 */
+	private void unlockSelectedVolume(String userPin) {
 		mVolumeFileSystem = mSelectedVolume.getFileSystem();
-
-		// If key caching is enabled, see if a key is cached
+		
+		// If key caching is enabled, see if a PIN is set and a key is cached
+		String savedPin = null;
 		byte[] cachedKey = null;
-		if (mPrefs.getBoolean("cache_key", false)) {
-			cachedKey = mApp.getDbHelper().getCachedKey(mSelectedVolume);
-		}
 
+		if (mPrefs.getBoolean("cache_key", false)) {
+			
+			savedPin = mApp.getDbHelper().getPIN(mSelectedVolume);
+			
+			if ((savedPin == null) || ((userPin != null) && userPin.equals(savedPin.toString()))) {
+				// all is well, give out cachedKey
+				cachedKey = mApp.getDbHelper().getCachedKey(mSelectedVolume);
+			} else if (userPin == null) {
+				// no PIN given, ask user for one
+				showDialog(DIALOG_VOL_PIN);
+				return;
+			} else {
+				// a wrong PIN was given
+				// TODO: increment / check fail counter
+				//userPin = null;
+				showDialog(DIALOG_VOL_PIN);
+				return;
+			}
+		}
+	
+		// pin is ok or missing but no key is cached
 		if (cachedKey == null) {
 			showDialog(DIALOG_VOL_PASS);
 		} else {
@@ -842,16 +908,16 @@ public class VolumeListActivity extends ListActivity implements
 
 		// Volume type
 		private FileSystem mFileSystem;
-
+		
 		// Cached key
 		private byte[] mCachedKey;
-
+		
 		// Path of the volume to unlock
 		private String mVolumePath;
 
 		// Password for unlocking (optional if cached key is given)
 		private String mPassword;
-
+		
 		// Optional custom config path
 		private String mConfigPath;
 
@@ -1371,10 +1437,12 @@ public class VolumeListActivity extends ListActivity implements
 							byte[] keyToCache = ovtr.volume.getDerivedKeyData();
 							mApp.getDbHelper().cacheKey(mSelectedVolume,
 									keyToCache);
+							// Ask user for a pin for this volume
+							showDialog(DIALOG_VOL_SETPIN);
 						}
 					}
-
-					launchVolumeBrowser(mSelectedVolIdx);
+					// TODO: does this work as it should?
+					//launchVolumeBrowser(mSelectedVolIdx);
 				}
 			}
 			break;

--- a/src/org/mrpdaemon/android/encdroid/VolumeListActivity.java
+++ b/src/org/mrpdaemon/android/encdroid/VolumeListActivity.java
@@ -491,8 +491,6 @@ public class VolumeListActivity extends ListActivity implements
 								if(value.length() > 0) {
 									mApp.getDbHelper().setPIN(mSelectedVolume,value.toString());
 								}
-								
-								// TODO: does this open the correct volume?
 								launchVolumeBrowser(mSelectedVolIdx);
 								break;
 							case DIALOG_VOL_CREATEPASS:
@@ -874,8 +872,6 @@ public class VolumeListActivity extends ListActivity implements
 				return;
 			} else {
 				// a wrong PIN was given
-				// TODO: increment / check fail counter
-				//userPin = null;
 				int pinAttempts = mApp.getDbHelper().getPINAttempts(mSelectedVolume);
 				
 				// we tolerate 3 wrong attempts, after that we delete the cached key
@@ -1453,10 +1449,10 @@ public class VolumeListActivity extends ListActivity implements
 									keyToCache);
 							// Ask user for a pin for this volume
 							showDialog(DIALOG_VOL_SETPIN);
+							break;
 						}
 					}
-					// TODO: does this work as it should?
-					//launchVolumeBrowser(mSelectedVolIdx);
+					launchVolumeBrowser(mSelectedVolIdx);
 				}
 			}
 			break;

--- a/src/org/mrpdaemon/android/encdroid/VolumeListActivity.java
+++ b/src/org/mrpdaemon/android/encdroid/VolumeListActivity.java
@@ -865,6 +865,9 @@ public class VolumeListActivity extends ListActivity implements
 			if ((savedPin == null) || ((userPin != null) && userPin.equals(savedPin.toString()))) {
 				// all is well, give out cachedKey
 				cachedKey = mApp.getDbHelper().getCachedKey(mSelectedVolume);
+				if(savedPin != null) {
+					mApp.getDbHelper().setPINAttempts(mSelectedVolume, 0);
+				}
 			} else if (userPin == null) {
 				// no PIN given, ask user for one
 				showDialog(DIALOG_VOL_PIN);
@@ -873,7 +876,17 @@ public class VolumeListActivity extends ListActivity implements
 				// a wrong PIN was given
 				// TODO: increment / check fail counter
 				//userPin = null;
-				mErrDialogText = getString(R.string.error_wrong_pin);
+				int pinAttempts = mApp.getDbHelper().getPINAttempts(mSelectedVolume);
+				
+				// we tolerate 3 wrong attempts, after that we delete the cached key
+				if(pinAttempts < 2) {
+					mApp.getDbHelper().setPINAttempts(mSelectedVolume, pinAttempts+1);
+					mErrDialogText = getString(R.string.error_wrong_pin);
+				} else {
+					mApp.getDbHelper().clearKey(mSelectedVolume);
+					mApp.getDbHelper().clearPIN(mSelectedVolume);
+					mErrDialogText = getString(R.string.error_wrong_pin_three_times);
+				}
 				showDialog(DIALOG_ERROR);
 				return;
 			}


### PR DESCRIPTION
This pull requests implements the following feature:
- If password caching is on and a password would be saved (e.g., after unlocking a volume for the first time), the user is asked first if he wants to set an optional PIN for that volume.
- Whenever the user unlocks a volume for which a password is cached and a PIN is set, he needs to enter that PIN.
- If a wrong PIN is entered, the volume is not unlocked. If a wrong PIN is entered three times, the password is deleted from the database and needs to be entered again.
- There are no additional UI elements and the PIN can only be changed by entering a wrong pin three times or by deleting the volume and adding it again.

With this, users can use secure (and thus hard to remember and type) passwords for their EncFS  containers without breaking usability. Still, if someone snatches their device, they cannot simply look at all volumes. At the same time, some volumes that are accessed very often, like volumes with notes, can still be accessed quickly.

This is the same idea I outlined in the discussion for #13. However, I now believe that PINs per volume are a somewhat different feature than a PIN for the whole app and that both features could also coexist.

Last note: PINs and passwords are saved unencrypted in the database, so this is not a security measure against sophisticated adversaries. 



